### PR TITLE
WIP Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS build
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS build
 
 RUN apt-get update && apt-get install -y \
     make \
@@ -11,15 +11,14 @@ RUN git clone https://github.com/dzaima/CBQN.git && \
     cd CBQN && \
     make
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
-RUN adduser --disabled-password --gecos "" appuser
+RUN useradd appuser
 
 WORKDIR /opt/test-runner
-COPY --from=build /tmp/CBQN/BQN .
 
-# COPY . .
+COPY --from=build /tmp/CBQN/BQN .
+# COPY --chown=appuser:appuser . .
 
 USER appuser
 # ENTRYPOINT [ "/opt/test-runner/bin/run.sh" ]
-

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -33,7 +33,7 @@ output_dir=$(realpath "${3%/}")
 mkdir -p "${output_dir}"
 
 # Build the Docker image
-docker build --rm -t exercism/test-runner .
+docker build --rm -t exercism/bqn-test-runner .
 
 # Run the Docker image using the settings mimicking the production environment
 docker run \
@@ -43,4 +43,4 @@ docker run \
     --mount type=bind,src="${solution_dir}",dst=/solution \
     --mount type=bind,src="${output_dir}",dst=/output \
     --mount type=tmpfs,dst=/tmp \
-    exercism/test-runner "${slug}" /solution /output 
+    exercism/bqn-test-runner "${slug}" /solution /output 

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -16,7 +16,7 @@
 set -e
 
 # Build the Docker image
-docker build --rm -t exercism/test-runner .
+docker build --rm -t exercism/bqn-test-runner .
 
 # Run the Docker image using the settings mimicking the production environment
 docker run \
@@ -28,4 +28,4 @@ docker run \
     --volume "${PWD}/bin/run-tests.sh:/opt/test-runner/bin/run-tests.sh" \
     --workdir /opt/test-runner \
     --entrypoint /opt/test-runner/bin/run-tests.sh \
-    exercism/test-runner
+    exercism/bqn-test-runner


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.